### PR TITLE
Add an opam file for easier development

### DIFF
--- a/opam
+++ b/opam
@@ -11,8 +11,10 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  ["./configure" "--bindir=%{bin}%"]
+  ["./configure" "--prefix" prefix]
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "pcap-format"]]

--- a/opam
+++ b/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: [ "Richard Mortier" "Richard Clegg" "Anil Madhavapeddy" "Dave Scott" ]
+license: "ISC"
+version: "0.5"
+homepage: "https://github.com/mirage/ocaml-pcap"
+dev-repo: "https://github.com/mirage/ocaml-pcap.git"
+bug-reports: "https://github.com/mirage/ocaml-pcap/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure" "--bindir=%{bin}%"]
+  [make]
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "pcap-format"]]
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "0.6.0"}
+  "lwt" {>= "2.4.0"}
+  "ocamlbuild" {build}
+]
+depopts: ["mirage-net"]
+conflicts: [
+  "mirage-net-socket"
+  "mirage" {< "0.9.2"}
+]


### PR DESCRIPTION
Note this also has a fix: add `./configure --bindir` which ensures the
ocap binary is installed in the right place (and not always in
`/usr/local/bin`)

Signed-off-by: David Scott <dave.scott@docker.com>