### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/pcap-format.opam
+++ b/pcap-format.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-pcap/"
 bug-reports: "https://github.com/mirage/ocaml-pcap/issues"
 depends: [
   "ocaml" {>="4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ppx_tools"
   "cstruct" {>= "1.9.0"}
   "ppx_cstruct"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.