### PR TITLE
requires ppx_cstruct > 0 (otherwise ppx_cstruct is known as cstruct.ppx iirc)

### DIFF
--- a/pcap-format.opam
+++ b/pcap-format.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "ppx_tools"
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct"
+  "ppx_cstruct" {> "0"}
   "ounit" {with-test}
   "mmap" {with-test}
 ]


### PR DESCRIPTION
this fix was applied on opam-repository but not upstreamed here (my bad) -- resulting in a new release of pcap-format (0.5.2) without this constraint that makes some CI systems fail (e.g. https://travis-ci.org/mirage/mirage-protocols/jobs/597723590)